### PR TITLE
feat: Permitir o uso da struct "Pix" fora da lib

### DIFF
--- a/src/efipay/efipay.go
+++ b/src/efipay/efipay.go
@@ -1,10 +1,10 @@
 package efipay
 
-type efipay struct {
+type Efipay struct {
 	endpoints
 }
 
-func NewEfiPay(configs map[string]interface{}) *efipay {
+func NewEfiPay(configs map[string]interface{}) *Efipay {
 	clientID := configs["client_id"].(string)
 	clientSecret := configs["client_secret"].(string)
 	sandbox := configs["sandbox"].(bool)
@@ -12,7 +12,7 @@ func NewEfiPay(configs map[string]interface{}) *efipay {
 	//partner_token := configs["partner_token"].(string)
 
 	requester := newRequester(clientID, clientSecret, sandbox, timeout)
-	efi := efipay{}
+	efi := Efipay{}
 	efi.requester = *requester
 	return &efi
 }

--- a/src/efipay/open_finance/efiPay_of.go
+++ b/src/efipay/open_finance/efiPay_of.go
@@ -1,10 +1,10 @@
 package open_finance
 
-type pix struct {
+type Of struct {
 	endpoints
 }
 
-func NewEfiPay(configs map[string]interface{}) *pix {
+func NewEfiPay(configs map[string]interface{}) *Of {
 	clientID := configs["client_id"].(string)
 	clientSecret := configs["client_secret"].(string)
 	CA := configs["CA"].(string)
@@ -12,8 +12,8 @@ func NewEfiPay(configs map[string]interface{}) *pix {
 	sandbox := configs["sandbox"].(bool)
 	timeout := configs["timeout"].(int)
 
-	requester := newRequester(clientID, clientSecret,CA, Key, sandbox, timeout)
-	efi := pix{}
+	requester := newRequester(clientID, clientSecret, CA, Key, sandbox, timeout)
+	efi := Of{}
 	efi.requester = *requester
 	return &efi
 }

--- a/src/efipay/payments/efiPay_payments.go
+++ b/src/efipay/payments/efiPay_payments.go
@@ -1,10 +1,10 @@
 package payments
 
-type pix struct {
+type Payment struct {
 	endpoints
 }
 
-func NewEfiPay(configs map[string]interface{}) *pix {
+func NewEfiPay(configs map[string]interface{}) *Payment {
 	clientID := configs["client_id"].(string)
 	clientSecret := configs["client_secret"].(string)
 	CA := configs["CA"].(string)
@@ -12,8 +12,8 @@ func NewEfiPay(configs map[string]interface{}) *pix {
 	sandbox := configs["sandbox"].(bool)
 	timeout := configs["timeout"].(int)
 
-	requester := newRequester(clientID, clientSecret,CA, Key, sandbox, timeout)
-	efi := pix{}
+	requester := newRequester(clientID, clientSecret, CA, Key, sandbox, timeout)
+	efi := Payment{}
 	efi.requester = *requester
 	return &efi
 }

--- a/src/efipay/pix/efiPay_pix.go
+++ b/src/efipay/pix/efiPay_pix.go
@@ -1,10 +1,10 @@
 package pix
 
-type pix struct {
+type Pix struct {
 	endpoints
 }
 
-func NewEfiPay(configs map[string]interface{}) *pix {
+func NewEfiPay(configs map[string]interface{}) *Pix {
 	clientID := configs["client_id"].(string)
 	clientSecret := configs["client_secret"].(string)
 	CA := configs["CA"].(string)
@@ -12,8 +12,8 @@ func NewEfiPay(configs map[string]interface{}) *pix {
 	sandbox := configs["sandbox"].(bool)
 	timeout := configs["timeout"].(int)
 
-	requester := newRequester(clientID, clientSecret,CA, Key, sandbox, timeout)
-	efi := pix{}
+	requester := newRequester(clientID, clientSecret, CA, Key, sandbox, timeout)
+	efi := Pix{}
 	efi.requester = *requester
 	return &efi
 }


### PR DESCRIPTION
* Eu gostaria de tornar possível utilizar a struct "Pix" (retorno de NewEfiPay) fora da lib. Isso permitiria receber o client como argumento em uma função, por exemplo