### PR TITLE
feat: make efipay package exportable

### DIFF
--- a/examples/exclusives/account/getAccountBalance.go
+++ b/examples/exclusives/account/getAccountBalance.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/gerencianet/gn-api-sdk-go/src/efipay/pix"
-	"github.com/gerencianet/gn-api-sdk-go/examples/configs"
+	"github.com/efipay/sdk-go-apis-efi/src/efipay/pix"
+	"github.com/efipay/sdk-go-apis-efi/examples/configs"
 )
 
 func main(){

--- a/examples/exclusives/account/updateAccountConfig.go
+++ b/examples/exclusives/account/updateAccountConfig.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/gerencianet/gn-api-sdk-go/src/efipay/pix"
-	"github.com/gerencianet/gn-api-sdk-go/examples/configs"
+	"github.com/efipay/sdk-go-apis-efi/src/efipay/pix"
+	"github.com/efipay/sdk-go-apis-efi/examples/configs"
 )
 
 func main(){

--- a/examples/pix/send/pixSendDetail.go
+++ b/examples/pix/send/pixSendDetail.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/gerencianet/gn-api-sdk-go/src/efipay/pix"
-	"github.com/gerencianet/gn-api-sdk-go/examples/configs"
+	"github.com/efipay/sdk-go-apis-efi/src/efipay/pix"
+	"github.com/efipay/sdk-go-apis-efi/examples/configs"
 )
 
 func main(){

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/efipay/sdk-go-apis-efi
+
+go 1.24.6

--- a/src/efipay/efipay.go
+++ b/src/efipay/efipay.go
@@ -1,10 +1,10 @@
 package efipay
 
-type efipay struct {
+type Efipay struct {
 	endpoints
 }
 
-func NewEfiPay(configs map[string]interface{}) *efipay {
+func NewEfiPay(configs map[string]interface{}) *Efipay {
 	clientID := configs["client_id"].(string)
 	clientSecret := configs["client_secret"].(string)
 	sandbox := configs["sandbox"].(bool)
@@ -12,7 +12,7 @@ func NewEfiPay(configs map[string]interface{}) *efipay {
 	//partner_token := configs["partner_token"].(string)
 
 	requester := newRequester(clientID, clientSecret, sandbox, timeout)
-	efi := efipay{}
+	efi := Efipay{}
 	efi.requester = *requester
 	return &efi
 }

--- a/src/efipay/efipay_test.go
+++ b/src/efipay/efipay_test.go
@@ -1,0 +1,99 @@
+package efipay
+
+import (
+	"testing"
+)
+
+func TestNewEfiPay(t *testing.T) {
+	// Configurações de teste
+	configs := map[string]interface{}{
+		"client_id":     "test_client_id",
+		"client_secret": "test_client_secret",
+		"sandbox":       true,
+		"timeout":       30,
+	}
+
+	// Testa a criação da instância Efipay
+	efi := NewEfiPay(configs)
+
+	// Verifica se a instância não é nil
+	if efi == nil {
+		t.Fatal("NewEfiPay retornou nil")
+	}
+
+	// Verifica se é do tipo correto
+	if efi == nil {
+		t.Errorf("NewEfiPay não retornou uma instância válida")
+	}
+}
+
+func TestNewEfiPayWithInvalidConfigs(t *testing.T) {
+	// Testa com configurações inválidas (deve causar panic)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("NewEfiPay deveria ter causado panic com configurações inválidas")
+		}
+	}()
+
+	// Configurações inválidas (faltando campos obrigatórios)
+	invalidConfigs := map[string]interface{}{
+		"client_id": "test_client_id",
+		// faltando client_secret, sandbox e timeout
+	}
+
+	NewEfiPay(invalidConfigs)
+}
+
+func TestNewEfiPayWithWrongTypes(t *testing.T) {
+	// Testa com tipos incorretos (deve causar panic)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("NewEfiPay deveria ter causado panic com tipos incorretos")
+		}
+	}()
+
+	// Configurações com tipos incorretos
+	wrongTypeConfigs := map[string]interface{}{
+		"client_id":     "test_client_id",
+		"client_secret": "test_client_secret",
+		"sandbox":       "true", // deveria ser bool
+		"timeout":       30,
+	}
+
+	NewEfiPay(wrongTypeConfigs)
+}
+
+func TestEfipayStructFields(t *testing.T) {
+	// Configurações de teste
+	configs := map[string]interface{}{
+		"client_id":     "test_client_id",
+		"client_secret": "test_client_secret",
+		"sandbox":       true,
+		"timeout":       30,
+	}
+
+	efi := NewEfiPay(configs)
+
+	// Verifica se a struct Efipay incorpora endpoints
+	// Testamos isso verificando se um método de endpoints está disponível
+	// Como CreateCharge é um método, apenas verificamos se podemos chamá-lo
+	// (não podemos comparar métodos com nil)
+	if efi == nil {
+		t.Errorf("Instância Efipay é nil")
+	}
+}
+
+// Teste de benchmark para medir performance da criação
+func BenchmarkNewEfiPay(b *testing.B) {
+	configs := map[string]interface{}{
+		"client_id":     "test_client_id",
+		"client_secret": "test_client_secret",
+		"sandbox":       true,
+		"timeout":       30,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		NewEfiPay(configs)
+	}
+}


### PR DESCRIPTION
Faz o pacote `efipay` se tornar exportável.

A modificação é importante p/ que o objeto do Efipay possa ser usado em construtores.